### PR TITLE
adding support for notmuch as a indexer

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,8 @@
 muttjump
 written by Johannes Weißl
 
-This script makes mail indexers (like mairix, mu or nmzmail) together with
-mutt more useful.
+This script makes mail indexers (like mairix, mu, nmzmail, or notmuch)
+together with mutt more useful.
 
 These search engines usually create a virtual maildir containing symbolic
 links to the original mails, which can be browsed using mutt.

--- a/muttjump
+++ b/muttjump
@@ -3,8 +3,8 @@
 
 # muttjump
 #
-# This script makes mail indexers (like mairix, mu or nmzmail) together with
-# mutt more useful.
+# This script makes mail indexers (like mairix, mu, nmzmail, or
+# notmuch) together with mutt more useful.
 #
 # These search engines usually create a virtual maildir containing symbolic
 # links to the original mails, which can be browsed using mutt.
@@ -18,7 +18,7 @@
 #
 # macro generic ,j "<enter-command>push <pipe-message>muttjump<enter><enter>" "jump to original message"
 
-# one of: mairix, mairix-git, mu, mu-old (mu < 0.7) and nmzmail
+# one of: mairix, mairix-git, mu, mu-old (mu < 0.7), nmzmail or notmuch (>0.5)
 MUTTJUMP_INDEXER=${MUTTJUMP_INDEXER:-}
 
 # "limit" or "search" (default)
@@ -51,6 +51,7 @@ MUTT=${MUTT:-mutt}
 MAIRIX=${MAIRIX:-mairix}
 MU=${MU:-mu}
 NMZMAIL=${NMZMAIL:-nmzmail}
+NOTMUCH=${NOTMUCH:-notmuch}
 SCREEN=${SCREEN:-screen}
 FORMAIL=${FORMAIL:-formail}
 REFORMAIL=${REFORMAIL:-reformail}
@@ -191,6 +192,9 @@ case $MUTTJUMP_INDEXER in
         orig_msgfiles=$(find "$nmzmail_results" -type l -exec readlink {} \;)
         rm -rf "$nmzmail_results"
         ;;
+    notmuch)
+	orig_msgfiles=$($NOTMUCH search --output=files "id:$msgid_clean")
+	;;
     "")
         die "variable MUTTJUMP_INDEXER not set or empty"
         ;;


### PR DESCRIPTION
This small patch adds support for using notmuch as a mail indexer in muttjump. Since notmuch added support for using a list of files as an output, I've switched to it from mairix. It's much faster.

The patch Works For Me. It should only work with versions of notmuch that are >=0.5.
