### PR TITLE
Support configuration file

### DIFF
--- a/muttjump
+++ b/muttjump
@@ -33,6 +33,12 @@
 # Note: The latter usage of the script can be activated by creating a symlink
 # called muttjump-same with this script as a target.
 
+MUTTJUMP_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/muttjump/muttjumprc"
+
+if [ -f $MUTTJUMP_CONFIG ] ; then
+    . $MUTTJUMP_CONFIG
+fi
+
 # one of: mairix, mairix-0.22, mu, mu-0.9.9.5, mu-0.6,
 #          nmzmail, or notmuch (>= 0.5)
 MUTTJUMP_INDEXER=${MUTTJUMP_INDEXER:-}


### PR DESCRIPTION
Configuration variables can be specified in
$XDG_CONFIG_HOME/muttjump/muttjumprc.